### PR TITLE
Fix RPMFusion in fedora syntax error

### DIFF
--- a/utils/distros/fedora.sh
+++ b/utils/distros/fedora.sh
@@ -56,7 +56,7 @@ function postinstall {
     esac
 
     # Install nonfree repos
-    sudo chroot $MNT /bin/bash -c "sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-\$(rpm -E %fedora).noarch.rpm -y"
+    sudo chroot $MNT /bin/bash -c "sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y"
 
     # Disable plymouth (sometimes fails for no apparent reason)
     runChrootCommand "plymouth-set-default-theme details -R &> /dev/null" || true


### PR DESCRIPTION
![Screenshot from 2022-01-10 18-40-47](https://user-images.githubusercontent.com/10627080/148745115-9a373bac-0e05-4d2a-9adb-69ae656ac8d4.png)
There is an error when trying to install fedora. 

line of RPMFusion installation causes syntax error.
Remove \ letter to fix it